### PR TITLE
Fix path in go mod

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.16.x
+          go-version: 1.19.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@master
         with:
-          go-version: 1.13.x
+          go-version: 1.16.x
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v1

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ publish.sh
 dist
 traductio.yaml
 traductio.yml
-
+traductio

--- a/cli.go
+++ b/cli.go
@@ -62,6 +62,7 @@ func NewApp() *App {
 }
 
 func (a *App) runCmd(cmd *cobra.Command, args []string) {
+	fmt.Printf("Run command: cfg=%s\n", a.cfgFile)
 	// validating the 'stopAfter' flag
 	if a.cfg.run.stopAfter != "" {
 		found := false
@@ -147,9 +148,10 @@ func (a *App) runCmd(cmd *cobra.Command, args []string) {
 		return
 	}
 	// STEP Store
-	fmt.Println("Going to create sink")
+	fmt.Println("Creating sink")
 	t, err := sink.New(c.Output)
 	exitOnErr(err)
+	fmt.Printf("Sink for %s created\n", t.GetName())
 
 	if len(points) < 1 {
 		fmt.Println("No data points to save")

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module traductio
 
-go 1.13
+go 1.16
 
 require (
 	github.com/aws/aws-lambda-go v1.26.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module traductio
 
-go 1.16
+go 1.19
 
 require (
 	github.com/aws/aws-lambda-go v1.26.0
@@ -9,16 +9,36 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.22.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamquery v1.9.0
 	github.com/aws/aws-sdk-go-v2/service/timestreamwrite v1.9.0
-	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/influxdata/influxdb-client-go/v2 v2.4.0
 	github.com/itchyny/gojq v0.12.6
-	github.com/kr/pretty v0.2.0 // indirect
 	github.com/mitchellh/go-homedir v1.1.0
-	github.com/smartystreets/goconvey v1.7.2 // indirect
 	github.com/spf13/cobra v0.0.0-20170905172051-b78744579491
-	github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1 // indirect
 	github.com/tj/go-naturaldate v1.3.0
 	golang.org/x/net v0.0.0-20210119194325-5f4716e94777
-	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 	gopkg.in/yaml.v2 v2.3.0
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2/aws/protocol/eventstream v1.0.0 // indirect
+	github.com/aws/aws-sdk-go-v2/credentials v1.6.5 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.8.2 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/configsources v1.1.2 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/endpoints/v2 v2.0.2 // indirect
+	github.com/aws/aws-sdk-go-v2/internal/ini v1.3.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/accept-encoding v1.5.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/endpoint-discovery v1.3.3 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.5.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.9.2 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.7.0 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.12.0 // indirect
+	github.com/aws/smithy-go v1.9.0 // indirect
+	github.com/deepmap/oapi-codegen v1.6.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/influxdata/line-protocol v0.0.0-20200327222509-2487e7298839 // indirect
+	github.com/itchyny/timefmt-go v0.1.3 // indirect
+	github.com/kr/pretty v0.2.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1 // indirect
+	golang.org/x/text v0.3.5 // indirect
+	gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 // indirect
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/geoadmin/traductiotraductio
+module github.com/geoadmin/traductio/traductio
 
 go 1.19
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module traductio
+module github.com/geoadmin/traductiotraductio
 
 go 1.19
 

--- a/go.sum
+++ b/go.sum
@@ -55,7 +55,6 @@ github.com/golangci/lint-1 v0.0.0-20181222135242-d2cdd8c08219/go.mod h1:/X8TswGS
 github.com/google/go-cmp v0.5.4/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.6 h1:BKbKCqvP6I+rmFHt06ZmyQtvB8xAkWdhFyr0ZUNZcxQ=
 github.com/google/go-cmp v0.5.6/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
-github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
 github.com/gorilla/mux v1.8.0/go.mod h1:DVbg23sWSpFRCP0SfiEN6jmj59UnW/n46BH5rLB71So=
 github.com/inconshreveable/mousetrap v1.0.0 h1:Z8tu5sraLXCXIcARxBp/8cbvlwVa7Z1NHg9XEKhtSvM=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
@@ -69,7 +68,6 @@ github.com/itchyny/timefmt-go v0.1.3 h1:7M3LGVDsqcd0VZH2U+x393obrzZisp7C0uEe921i
 github.com/itchyny/timefmt-go v0.1.3/go.mod h1:0osSSCQSASBJMsIZnhAaF1C2fCBTJZXrnj37mG8/c+A=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
-github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.0 h1:s5hAObm+yFO5uHYt5dYjxi2rXrsnmRpJx4OYvIWUaQs=
 github.com/kr/pretty v0.2.0/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=
@@ -98,9 +96,6 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
-github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
-github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
-github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
 github.com/spf13/cobra v0.0.0-20170905172051-b78744579491 h1:XOya2OGpG7Q4gS4MYHRoFSTlBGnZD40X+Kw2ikFQFXE=
 github.com/spf13/cobra v0.0.0-20170905172051-b78744579491/go.mod h1:1l0Ry5zgKvJasoi3XT1TypsSe7PqH0Sj9dhYf7v3XqQ=
 github.com/spf13/pflag v1.0.1-0.20170901120850-7aff26db30c1 h1:eOB1Xq3T1JrZBdEhs4D+MhPROyvo149AJawmtL0SOA4=
@@ -123,7 +118,6 @@ golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACk
 golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
 golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
-golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20200822124328-c89045814202/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
@@ -152,8 +146,6 @@ golang.org/x/text v0.3.5/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/time v0.0.0-20201208040808-7e3f01d25324/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/time v0.0.0-20210220033141-f8bda1e9f3ba/go.mod h1:tRJNPiyCQ0inRvYxbN9jk5I+vvW/OXSQhTDSoE431IQ=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
-golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
-golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f h1:kDxGY2VmgABOe55qheT/TFqUMtcTHnomIPS1iv3G4Ms=
 golang.org/x/tools v0.0.0-20191125144606-a911d9008d1f/go.mod h1:b+2E5dAYhXwXZwtnZ6UAqBI28+e2cm9otk0dWdXHAEo=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=

--- a/internal/sink/influx/influx.go
+++ b/internal/sink/influx/influx.go
@@ -13,6 +13,7 @@ func init() {
 }
 
 type Influx struct {
+	Name   string
 	Client influxdb2.Client
 	Bucket string
 	Org    string
@@ -44,6 +45,7 @@ func setup(config map[string]string) (sink.Sink, error) {
 	c := influxdb2.NewClientWithOptions(addr, token, influxdb2.DefaultOptions().SetBatchSize(20))
 
 	i = Influx{
+		Name: fmt.Sprintf("influx:%s:%s", config["bucket"], config["series"]),
 		Client: c,
 		Org:    org,
 		Bucket: bucket,
@@ -76,4 +78,8 @@ func (i Influx) Write(points []sink.Point) error {
 
 func (i Influx) Close() {
 	i.Client.Close()
+}
+
+func (i Influx) GetName() string {
+	return i.Name
 }

--- a/internal/sink/sinks.go
+++ b/internal/sink/sinks.go
@@ -33,6 +33,7 @@ func (c Config) Validate() ([]string, error) {
 // Sink interface needs to be implemented in order to provide a Sink
 // backend such as InfluxDB.
 type Sink interface {
+	GetName() string
 	Write(points []Point) error
 	Close()
 	//Query(cmd string) (res []client.Result, err error)

--- a/internal/sink/timestream/timestream.go
+++ b/internal/sink/timestream/timestream.go
@@ -22,6 +22,7 @@ func init() {
 }
 
 type Timestream struct {
+	Name        string
 	DB          string
 	WriteClient *timestreamwrite.Client
 	QueryClient *timestreamquery.Client
@@ -70,6 +71,8 @@ func setup(c map[string]string) (sink.Sink, error) {
 
 	t.DB = db
 	t.Series = series
+
+	t.Name = fmt.Sprintf("timestream:%s:%s", c["db"], c["series"])
 
 	return t, nil
 }
@@ -130,4 +133,8 @@ func (t Timestream) Write(points []sink.Point) error {
 }
 
 func (t Timestream) Close() {
+}
+
+func (t Timestream) GetName() string {
+	return t.Name
 }


### PR DESCRIPTION
Installing via `go get` is deprecated. Installation via `go install` requires this adaption in `go.mod`